### PR TITLE
Add config for reporting missing documentation

### DIFF
--- a/lib/AtomConfig.coffee
+++ b/lib/AtomConfig.coffee
@@ -28,6 +28,7 @@ class AtomConfig extends Config
         @set('showUnknownGlobalFunctions', atom.config.get("#{@packageName}.showUnknownGlobalFunctions"))
         @set('showUnknownGlobalConstants', atom.config.get("#{@packageName}.showUnknownGlobalConstants"))
         @set('showUnusedUseStatements', atom.config.get("#{@packageName}.showUnusedUseStatements"))
+        @set('showMissingDocs', atom.config.get("#{@packageName}.showMissingDocs"))
         @set('validateDocblockCorrectness', atom.config.get("#{@packageName}.validateDocblockCorrectness"))
 
     ###*
@@ -48,6 +49,9 @@ class AtomConfig extends Config
 
         atom.config.onDidChange "#{@packageName}.showUnusedUseStatements", () =>
             @set('showUnusedUseStatements', atom.config.get("#{@packageName}.showUnusedUseStatements"))
+
+        atom.config.onDidChange "#{@packageName}.showMissingDocs", () =>
+            @set('showMissingDocs', atom.config.get("#{@packageName}.showMissingDocs"))
 
         atom.config.onDidChange "#{@packageName}.validateDocblockCorrectness", () =>
             @set('validateDocblockCorrectness', atom.config.get("#{@packageName}.validateDocblockCorrectness"))

--- a/lib/Config.coffee
+++ b/lib/Config.coffee
@@ -27,6 +27,7 @@ class Config
             showUnknownGlobalFunctions  : true
             showUnknownGlobalConstants  : true
             showUnusedUseStatements     : true
+            showMissingDocs             : true
             validateDocblockCorrectness : true
 
         @load()

--- a/lib/Main.coffee
+++ b/lib/Main.coffee
@@ -48,6 +48,15 @@ module.exports =
             default     : true
             order       : 5
 
+        showMissingDocs:
+            title       : 'Show missing phpdocumentations'
+            description : '''
+                Highlights any missing php documentation on functions/methods/classes/fields.
+            '''
+            type        : 'boolean'
+            default     : true
+            order       : 6
+
         validateDocblockCorrectness:
             title       : 'Validate docblock correctness'
             description : '''

--- a/lib/SemanticLintProvider.coffee
+++ b/lib/SemanticLintProvider.coffee
@@ -140,7 +140,6 @@ class IndexingProvider
             noUnknownGlobalFunctions : not @config.get('showUnknownGlobalFunctions')
             noUnknownGlobalConstants : not @config.get('showUnknownGlobalConstants')
             noUnusedUseStatements    : not @config.get('showUnusedUseStatements')
-            noMissingDocs            : not @config.get('showMissingDocs')
             noDocblockCorrectness    : not @config.get('validateDocblockCorrectness')
         }
 
@@ -237,13 +236,14 @@ class IndexingProvider
                     "The docblock for <strong>#{item.name}</strong> is missing a @var tag."
                 )
 
-            for item in response.warnings.docblockIssues.missingDocumentation
-                messages.push @createLinterMessageForOutputItem(
-                    editor,
-                    item,
-                    'Warning',
-                    "Documentation for <strong>#{item.name}</strong> is missing."
-                )
+            if @config.get('showMissingDocs')
+                for item in response.warnings.docblockIssues.missingDocumentation
+                    messages.push @createLinterMessageForOutputItem(
+                        editor,
+                        item,
+                        'Warning',
+                        "Documentation for <strong>#{item.name}</strong> is missing."
+                    )
 
             for item in response.warnings.docblockIssues.parameterMissing
                 messages.push @createLinterMessageForOutputItem(

--- a/lib/SemanticLintProvider.coffee
+++ b/lib/SemanticLintProvider.coffee
@@ -140,6 +140,7 @@ class IndexingProvider
             noUnknownGlobalFunctions : not @config.get('showUnknownGlobalFunctions')
             noUnknownGlobalConstants : not @config.get('showUnknownGlobalConstants')
             noUnusedUseStatements    : not @config.get('showUnusedUseStatements')
+            noMissingDocs            : not @config.get('showMissingDocs')
             noDocblockCorrectness    : not @config.get('validateDocblockCorrectness')
         }
 


### PR DESCRIPTION
Ref #43 

This PR introduces a new config for reporting missing documentation and a check to enforce the warning in `SemanticLinterProvider`. There is no changes on the php-side, only coffee-side.

Is there a concern that the php-side will process warnings for missing docs to just end up throwing them out the window?
